### PR TITLE
feat: manual release workflow (bump pyproject version + uv build + GitHub Release)

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,106 @@
+name: create-release
+
+# Bumps the version in pyproject.toml, commits + tags it, builds the
+# package with uv and creates a GitHub Release with the wheel/sdist.
+#
+# Trigger:  Settings-independent manual dispatch (Actions tab -> create-release):
+#           bump:    patch | minor | major   (applied to the CURRENT version in pyproject.toml)
+#           publish: create the release (default: true)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump to apply to the current version in pyproject.toml'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      publish:
+        description: 'Build the package and create a GitHub Release with the artifacts'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  # Job 1: read the current version, bump it in pyproject.toml, commit + tag.
+  update-version:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    outputs:
+      VERSION: ${{ steps.bump.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version in pyproject.toml (relative to the current version)
+        id: bump
+        env:
+          BUMP: ${{ github.event.inputs.bump }}
+        run: |
+          NEW_VERSION="$(python3 scripts/bump_version.py --"$BUMP")"
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "New version: ${NEW_VERSION}"
+
+      - name: Commit, tag and push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore(release): $VERSION"
+          git push origin HEAD
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+  # Job 2: build and create the release (only if publish=true).
+  # On a re-run of failed jobs, only this job is re-executed, so the
+  # version from Job 1 is never bumped twice.
+  create-release:
+    runs-on: ubuntu-latest
+    needs: update-version
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository at the new tag
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.update-version.outputs.VERSION }}
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: '0.6.7'
+
+      - name: Set up Python (as required by pyproject.toml)
+        run: uv python install
+
+      - name: Build package (wheel + sdist)
+        run: uv build
+
+      - name: Verify artifacts
+        run: ls -lh dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ needs.update-version.outputs.VERSION }}
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          generate_release_notes: true

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Bump the package version in pyproject.toml and print the new version.
+
+The current version is read from the file (source of truth), so this always
+works relative to whatever version is currently set:
+
+    python scripts/bump_version.py --patch    # 0.6.0 -> 0.6.1
+    python scripts/bump_version.py --minor    # 0.6.0 -> 0.7.0
+    python scripts/bump_version.py --major    # 0.6.0 -> 1.0.0
+
+Stdlib only; used directly by .github/workflows/create_release.yml.
+"""
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION_RE = re.compile(r'(?m)^version\s*=\s*"\d+\.\d+\.\d+"')
+
+
+def bump_version(text: str, mode: str) -> str:
+    """Return the new version string, given the file content and a bump mode."""
+    match = re.search(r'version\s*=\s*"(\d+)\.(\d+)\.(\d+)"', text)
+    if match is None:
+        raise SystemExit('ERROR: no `version = "X.Y.Z"` line found in pyproject.toml')
+    major, minor, patch = (int(g) for g in match.groups())
+    if mode == "major":
+        major, minor, patch = major + 1, 0, 0
+    elif mode == "minor":
+        minor, patch = minor + 1, 0
+    else:  # patch
+        patch += 1
+    return f"{major}.{minor}.{patch}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--major", action="store_const", dest="mode", const="major")
+    group.add_argument("--minor", action="store_const", dest="mode", const="minor")
+    group.add_argument("--patch", action="store_const", dest="mode", const="patch")
+    parser.add_argument("--file", default="pyproject.toml", help="Path to pyproject.toml")
+    args = parser.parse_args()
+
+    path = Path(args.file)
+    text = path.read_text(encoding="utf-8")
+    new_version = bump_version(text, args.mode)
+    new_text, n_subs = VERSION_RE.subn(f'version = "{new_version}"', text, count=1)
+    if n_subs != 1:
+        raise SystemExit(f"ERROR: could not write version in {path}")
+    path.write_text(new_text, encoding="utf-8")
+    print(new_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

New manual GitHub Actions workflow **create-release** (Actions tab) that:

1. Reads the **current version from pyproject.toml** and bumps it by the chosen amount (patch / minor / major)
2. Commits the change back to master, tags it (vX.Y.Z), pushes
3. Builds the package with **uv** and creates a **GitHub Release** with the wheel + sdist

### Inputs (manual trigger only — no automatic releases)

| input | type | default | meaning |
|---|---|---|---|
| `bump` | choice | — (required) | patch / minor / major, applied to the CURRENT version |
| `publish` | boolean | `true` | build + create the release. Set `false` to skip the build/release step (the bump commit + tag still happen) |

### Files

- `scripts/bump_version.py` — stdlib-only bump script; source of truth is **pyproject.toml, not git tags** (which is the key adaptation from the template)
- `.github/workflows/create_release.yml` — two jobs: `update-version` → `create-release`

Adapted from *PermafrostDiscoveryGateway/water-timeseries-v2* `update_version.yml`: version source switched from git tags to pyproject.toml, and the Docker / docs / Helm-chart jobs were dropped (not applicable to this package).

## How to use

1. Go to **Actions → create-release → Run workflow**
2. Pick the bump (patch / minor / major) — it's always relative to whatever version is currently in `pyproject.toml`, so it reads the current value and increments from there (your requirement #3)
3. `publish: true` (default) → full release with artifacts; `false` → bump + tag only
4. Done: a commit like `chore(release): 0.6.1` lands on master, tag `v0.6.1` is pushed, and a GitHub Release with the `.whl` + `.tar.gz` is created

## Verified (executed locally)

| Check | Result |
|---|---|
| Bump script `--patch` / `--minor` / `--major` starting from 0.6.0 | 0.6.1 → 0.7.0 → 1.0.0 (file restored after test) |
| `uv build` with the bumped version (as Job 2 runs) | produced `noaaplotter-0.6.2-py3-none-any.whl` + `noaaplotter-0.6.2.tar.gz` |
| Workflow YAML: parses, job graph (`needs`), per-job `permissions`, dispatch inputs | OK |
| No new secrets needed | `GITHUB_TOKEN` carries `contents: write`, which covers the push, tag, and release |

## One thing to note

The bump commit is pushed to **master directly** (same as the template — `git push origin HEAD`). If you'd rather route release commits through a PR instead, say the word and I'll switch Job 1 to `gh pr create` and let `create-release` trigger on merge.
