### PR TITLE
feat: interactive daily plot — full series, proper y-limits, year bands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ noaaplotter plot-daily -infile data/kotzebue.parquet -start 2017-07-01 -end 2018
 | `-save_plot` | write the plot (`.png` for matplotlib, `.html` for plotly) |
 | `--plot` | open in a browser/GUI |
 | `--engine` | `matplotlib` (default) or `plotly` |
+| `--full-series` | plotly only: include the entire observed record in the HTML plot — the view still opens on the selected period (default: plot only the selected period, smaller file) |
 
 ### `noaaplotter plot-monthly`
 Monthly bar chart of temperature or precipitation, with anomaly and trailing mean.

--- a/noaaplotter/cli/__init__.py
+++ b/noaaplotter/cli/__init__.py
@@ -107,6 +107,7 @@ def plot_daily(
     figsize: Optional[Tuple[float, float]] = typer.Option(None, "-figsize", help="Figure size in inches, width height (e.g. 15 10 for 2 years)"),
     title: Optional[str] = typer.Option(None, "-title", help="Plot title"),
     engine: str = typer.Option("matplotlib", "--engine", help="Rendering engine: matplotlib (static) or plotly (interactive HTML)"),
+    full_series: bool = typer.Option(False, "--full-series", help="plotly only: include the ENTIRE observed record in the interactive plot; the initial view is still limited to the requested period (default: plot only the requested period, lightweight)"),
 ):
     """Create a daily temperature/precipitation plot vs. climate.
 
@@ -137,6 +138,7 @@ def plot_daily(
         figsize=fsize,
         title=title,
         engine=engine,
+        full_series=full_series,
     )
     _report(save_path, show_plot, engine)
 

--- a/noaaplotter/figures/__init__.py
+++ b/noaaplotter/figures/__init__.py
@@ -1,5 +1,5 @@
 """Plotly figure builders — interactive versions of the matplotlib plots."""
-from .plotly_daily import make_daily_figure, write_daily_html
+from .plotly_daily import make_daily_figure
 from .plotly_monthly import make_monthly_figure
 
-__all__ = ["make_daily_figure", "write_daily_html", "make_monthly_figure"]
+__all__ = ["make_daily_figure", "make_monthly_figure"]

--- a/noaaplotter/figures/__init__.py
+++ b/noaaplotter/figures/__init__.py
@@ -1,5 +1,5 @@
 """Plotly figure builders — interactive versions of the matplotlib plots."""
-from .plotly_daily import make_daily_figure
+from .plotly_daily import make_daily_figure, write_daily_html
 from .plotly_monthly import make_monthly_figure
 
-__all__ = ["make_daily_figure", "make_monthly_figure"]
+__all__ = ["make_daily_figure", "write_daily_html", "make_monthly_figure"]

--- a/noaaplotter/figures/plotly_daily.py
+++ b/noaaplotter/figures/plotly_daily.py
@@ -2,8 +2,14 @@
 
 Mirrors `NOAAPlotter.plot_weather_series`: temperature panel (observed vs
 climatological mean +/- std with red/blue fill, no-data shading, record
-markers) plus precipitation panel (bars, no-data shading, optional
-cumulative snowfall on a secondary axis).
+markers) plus precipitation panel (bars, 7-day rolling sum, no-data shading,
+optional cumulative snowfall on a secondary axis).
+
+When `window=(start, end)` is given (the user's selected plotting period) the
+figure carries the ENTIRE observed series and only the initial view is limited
+to that window — users can zoom out step by step ("1y / 3y / All" buttons) to
+browse the full record.  When no window is given the old behaviour applies
+(the series shown is exactly what is passed in).
 """
 import numpy as np
 import pandas as pd
@@ -12,6 +18,7 @@ from plotly.subplots import make_subplots
 
 C_HIGH = "#d6604d"
 C_LOW = "#4393c3"
+YEAR_BAND = "rgba(0,0,0,0.025)"  # light grey per calendar year (even years white)
 
 
 def _clean(v):
@@ -43,33 +50,75 @@ def _fill_band(xs, bottom, top, hexcolor, alpha, name=None, showlegend=False):
                       name=name, showlegend=showlegend)
 
 
+def _add_year_bands(fig, dates, row):
+    """Alternating light-grey / white background bands per calendar year.
+
+    Odd years get a very light grey band, even years stay white — same
+    convention as the monthly plots.  ``add_shape`` with ``yref='paper'``
+    spans the full plot height of the given subplot row.
+    """
+    years = sorted({d.year for d in dates})
+    axis = f"y{row}" if row != 1 else "y"
+    for year in years:
+        if year % 2 == 0:
+            continue  # white: nothing to draw
+        fig.add_shape(
+            type="rect",
+            x0=f"{year}-01-01",
+            x1=f"{year}-12-31",
+            y0=0, y1=1,
+            yref=f"{axis} domain",
+            xref=f"x{row}" if row != 1 else "x",
+            fillcolor=YEAR_BAND,
+            line_width=0,
+            layer="below",
+        )
+
+
 def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_lo,
                       ext_hi=None, ext_lo=None, snow_dates=None, snow_acc=None,
                       snow_tail=None, show_snow_accumulation=True,
                       plot_pmax=None, plot_snowmax=None, title=None,
-                      figsize=(900, 600)):
-    dates = list(x_dates_short["DATE"])
-    xfull = list(x_dates["DATE"])
+                      figsize=(900, 600), window=None):
+    """Build the interactive daily figure.
+
+    window : (start, end) timestamps, optional
+        Initial visible x-range.  When set, the full observed series is shown
+        and only the initial view is clipped to this period.
+    """
+    if x_dates_short is not None:
+        dates = list(x_dates_short["DATE"])
+    else:
+        dates = list(df_obs["DATE"])
+    xfull = list(x_dates["DATE"]) if x_dates is not None else dates
     obs = np.asarray(df_obs["TMEAN"], dtype=float)
     prcp = np.asarray(df_obs["PRCP"], dtype=float)
     # Full-window climatology (drives the reference lines, so the x-axis still
     # runs to the requested end date even when it lies in the future).
     clim_full = np.asarray(y_clim, dtype=float)
-    clim_hi_full = np.asarray(y_clim_hi, dtype=float)
-    clim_lo_full = np.asarray(y_clim_lo, dtype=float)
+    clim_hi_full = np.asarray(y_clim_hi if y_clim_hi is not None else y_clim, dtype=float)
+    clim_lo_full = np.asarray(y_clim_lo if y_clim_lo is not None else y_clim, dtype=float)
     # Climatology aligned to the OBSERVED span. The requested window may extend
     # past the last available data (future end date); every trace derived from
     # the observed series must line up with it — mirroring the static render,
     # which fills against y_clim.loc[clim_locs_short].
-    clim = np.asarray(y_clim.reindex(df_obs["DATE"]), dtype=float)
-    clim_hi = np.asarray(y_clim_hi.reindex(df_obs["DATE"]), dtype=float)
-    clim_lo = np.asarray(y_clim_lo.reindex(df_obs["DATE"]), dtype=float)
-    
-    # Create 7-day rolling sum of precipitation
+    if y_clim is not None:
+        clim = np.asarray(y_clim.reindex(df_obs["DATE"]), dtype=float)
+        clim_hi = np.asarray(y_clim_hi.reindex(df_obs["DATE"]), dtype=float)
+        clim_lo = np.asarray(y_clim_lo.reindex(df_obs["DATE"]), dtype=float)
+    else:
+        clim = clim_hi = clim_lo = np.full(len(df_obs), np.nan)
+
+    # 7-day rolling sum of precipitation (computed early: the precipitation
+    # y-range must include it so the full line is visible initially)
     prcp_rolling = pd.Series(prcp).rolling(window=7, min_periods=1, center=True).sum()
 
     fig = make_subplots(rows=2, cols=1, shared_xaxes=True,
                         row_heights=[0.6, 0.4], vertical_spacing=0.07)
+
+    # --- calendar-year background bands (light grey / white), both panels
+    for row in (1, 2):
+        _add_year_bands(fig, dates, row)
 
     # --- temperature: soft light-grey climatological +/- sigma envelope (no hover)
     fig.add_trace(_grey_band(dates, clim_hi, clim_lo), 1, 1)
@@ -111,7 +160,9 @@ def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_
                              line=dict(color="rgba(0,0,0,0.4)", width=1.2),
                              hovertemplate="Observed: %{y:.2f} °C<extra></extra>"), 1, 1)
 
-    # --- temperature: y-range + no-data shading + zero line
+    # --- temperature: y-range + no-data shading + zero line.
+    # The range covers EVERYTHING visible (observed series AND climatology)
+    # so no value is clipped in the initial view.
     span_hi = float(np.nanmax(np.concatenate([obs, clim_hi_full])))
     span_lo = float(np.nanmin(np.concatenate([obs, clim_lo_full])))
     fig.update_yaxes(range=[span_lo, span_hi], title="Temperature in °C",
@@ -136,10 +187,16 @@ def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_
                                  marker=dict(symbol="x", size=8, color=C_LOW),
                                  hovertemplate="Record low: %{y:.2f} °C<extra></extra>"), 1, 1)
 
-    # --- precipitation: bars + no-data shading
-    prcp_top = (float(np.nanmax(prcp) * 1.15) if np.nanmax(prcp) > 0 else 1.0)
+    # --- precipitation: bars + no-data shading.
+    # y-range includes the 7-day rolling sum (often higher than the max daily
+    # bar) so the full rolling line is visible in the initial view.
+    rolling_max = float(np.nanmax(prcp_rolling.to_numpy()))
+    rolling_max = rolling_max if np.isfinite(rolling_max) else 0.0
     if plot_pmax is not None:
-        prcp_top = plot_pmax
+        prcp_top = float(plot_pmax)
+    else:
+        base = float(np.nanmax(prcp)) if np.size(prcp) else 0.0
+        prcp_top = max(base * 1.15, rolling_max * 1.15, 1.0)
     fig.update_yaxes(range=[0, prcp_top], title="Precipitation in mm", row=2, col=1)
     fig.add_trace(go.Bar(x=dates, y=list(pd.Series(prcp).where(pd.notna(prcp))),
                          name="Precipitation", marker_color=C_LOW,
@@ -149,8 +206,8 @@ def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_
         fig.add_trace(go.Bar(x=nan_p, y=[prcp_top] * len(nan_p), base=0, width=1,
                              marker_color="rgba(0,0,0,0.2)",
                              name="No Data", showlegend=True), 2, 1)
-    
-    # --- rolling 7-day precipitation sum: line + no-data shading
+
+    # --- rolling 7-day precipitation sum
     # Convert to list for Plotly
     prcp_rolling_list = list(prcp_rolling.where(pd.notna(prcp_rolling)))
     fig.add_trace(go.Scatter(x=dates, y=prcp_rolling_list,
@@ -180,13 +237,27 @@ def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_
                                      line=dict(color="black", width=1, dash="dash"),
                                      showlegend=False, yaxis="y3"))
 
-    fig.update_layout(height=figsize[1], width=figsize[0],
-                      template="plotly_white", hovermode="x unified",
-                      showlegend=True,
-                      legend=dict(orientation="h", yanchor="bottom", y=1.02,
-                                  xanchor="left", x=0),
-                      margin=dict(l=40, r=40, t=50 if title else 40, b=30),
-                      title=dict(text=title, y=0.98) if title else None,
-                      xaxis_rangeslider_visible=False,
-                      xaxis_title="Date")
+    layout = dict(height=figsize[1], width=figsize[0],
+                  template="plotly_white", hovermode="x unified",
+                  showlegend=True,
+                  legend=dict(orientation="h", yanchor="bottom", y=1.02,
+                              xanchor="left", x=0),
+                  margin=dict(l=40, r=40, t=50 if title else 40, b=30),
+                  title=dict(text=title, y=0.98) if title else None,
+                  xaxis_rangeslider_visible=False,
+                  xaxis_title="Date")
+    if window is not None:
+        # Initial view = the selected period; zoom buttons let the user
+        # step out (1 year / 3 years / All) to browse the full record.
+        layout["xaxis_range"] = [
+            pd.Timestamp(window[0]).strftime("%Y-%m-%d"),
+            pd.Timestamp(window[1]).strftime("%Y-%m-%d"),
+        ]
+        layout["xaxis_rangeselector"] = dict(
+            buttons=[
+                dict(count=1, label="1y", step="year", stepmode="backward"),
+                dict(count=3, label="3y", step="year", stepmode="backward"),
+                dict(step="all", label="All"),
+            ])
+    fig.update_layout(**layout)
     return fig

--- a/noaaplotter/figures/plotly_daily.py
+++ b/noaaplotter/figures/plotly_daily.py
@@ -246,18 +246,88 @@ def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_
                   title=dict(text=title, y=0.98) if title else None,
                   xaxis_rangeslider_visible=False,
                   xaxis_title="Date")
+    # --- initial x-view + zoom-out controls (window = user-selected period)
+    # NOTE: with shared_xaxes the visible master axis is x2 (xaxis "matches"
+    # it and is hidden), so the initial range must be applied to BOTH.
     if window is not None:
-        # Initial view = the selected period; zoom buttons let the user
-        # step out (1 year / 3 years / All) to browse the full record.
-        layout["xaxis_range"] = [
-            pd.Timestamp(window[0]).strftime("%Y-%m-%d"),
-            pd.Timestamp(window[1]).strftime("%Y-%m-%d"),
+        d0 = pd.Timestamp(window[0]).strftime("%Y-%m-%d")
+        d1 = pd.Timestamp(window[1]).strftime("%Y-%m-%d")
+        layout["xaxis_range"] = [d0, d1]
+        layout["xaxis2_range"] = [d0, d1]
+
+        data_lo = min(dates).strftime("%Y-%m-%d")
+        data_hi = max(dates).strftime("%Y-%m-%d")
+
+        # Visible "legend-style" zoom buttons (top row, right side; the
+        # legend is anchored left, so nothing is covered).  Clicks are
+        # wired by the post-script (injected by write_html); each button
+        # keeps the CENTER of the current view and widens around it, so
+        # repeated presses step outward instead of drifting to later years.
+        layout["annotations"] = [
+            dict(text=lab, xref="paper", yref="paper",
+                 x=0.975 - 0.045 * i, y=0.99,
+                 showarrow=False, align="center",
+                 bordercolor="#94a3b8", borderwidth=1, borderpad=3,
+                 bgcolor="white",
+                 font=dict(size=13, color="#1f2937",
+                           family="Segoe UI, Arial, sans-serif"),
+                 opacity=1)
+            for i, lab in enumerate(["1y", "3y", "All"])
         ]
-        layout["xaxis_rangeselector"] = dict(
-            buttons=[
-                dict(count=1, label="1y", step="year", stepmode="backward"),
-                dict(count=3, label="3y", step="year", stepmode="backward"),
-                dict(step="all", label="All"),
-            ])
     fig.update_layout(**layout)
     return fig
+
+
+def write_daily_html(fig, path, data_lo=None, data_hi=None):
+    """Write the figure HTML, then inject the zoom-button click behaviour.
+
+    The plotly Figure object rejects non-standard attributes (e.g.
+    ``post_script``), so the small click handler is appended to the saved
+    HTML file directly — which is fully under our control.
+    """
+    import re
+
+    fig.write_html(path)
+    with open(path, "r", encoding="utf-8") as f:
+        html = f.read()
+
+    if data_lo is None or data_hi is None:
+        return
+
+    script = (
+        "<script>(function(){"
+        "function getGd(){"
+        "if(window.Plotly&&Plotly.figs){var k=Object.keys(Plotly.figs);if(k.length)return Plotly.figs[k[0]];} "
+        "var d=document.querySelectorAll('div');"
+        "for(var i=0;i<d.length;i++){if(d[i]._fullLayout)return d[i];}"
+        "return null;"
+        "}"
+        "var div=getGd();"
+        "if(!div)return;"
+        "var full=['" + data_lo + "','" + data_hi + "'];"
+        "var DAY=86400000;"
+        "function iso(ms){return new Date(ms).toISOString().slice(0,10);} "
+        "function setRange(a,b){Plotly.relayout(div,{'xaxis.range':[a,b],'xaxis2.range':[a,b]});} "
+        "function centerZoom(months){"
+        "var r=(div.layout&&div.layout.xaxis2&&div.layout.xaxis2.range)||"
+        "(div.layout&&div.layout.xaxis.range);"
+        "if(!r)return;"
+        "var a=Date.parse(r[0]),b=Date.parse(r[1]);"
+        "if(isNaN(a)||isNaN(b))return;"
+        "var span=Math.max(b-a,months*30*DAY);"
+        "var mid=a+(b-a)/2;"
+        "setRange(iso(mid-span/2),iso(mid+span/2));"
+        "}"
+        "div.addEventListener('click',function(e){"
+        "var el=e.target;"
+        "var g=el&&el.closest?el.closest('g'):null;"
+        "var txt=((g&&g.textContent)||(el&&el.textContent)||'').trim();"
+        "if(txt==='1y')centerZoom(12);"
+        "else if(txt==='3y')centerZoom(36);"
+        "else if(txt==='All')setRange(full[0],full[1]);"
+        "});"
+        "})();</script>"
+    )
+    html = html.replace("</body>", script + "\n</body>", 1)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(html)

--- a/noaaplotter/figures/plotly_daily.py
+++ b/noaaplotter/figures/plotly_daily.py
@@ -7,9 +7,9 @@ optional cumulative snowfall on a secondary axis).
 
 When `window=(start, end)` is given (the user's selected plotting period) the
 figure carries the ENTIRE observed series and only the initial view is limited
-to that window — users can zoom out step by step ("1y / 3y / All" buttons) to
-browse the full record.  When no window is given the old behaviour applies
-(the series shown is exactly what is passed in).
+to that window — users can zoom out manually to browse the full record.
+When no window is given the old behaviour applies (the series shown is
+exactly what is passed in).
 """
 import numpy as np
 import pandas as pd
@@ -246,7 +246,7 @@ def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_
                   title=dict(text=title, y=0.98) if title else None,
                   xaxis_rangeslider_visible=False,
                   xaxis_title="Date")
-    # --- initial x-view + zoom-out controls (window = user-selected period)
+    # --- initial x-view (window = user-selected period).
     # NOTE: with shared_xaxes the visible master axis is x2 (xaxis "matches"
     # it and is hidden), so the initial range must be applied to BOTH.
     if window is not None:
@@ -254,80 +254,5 @@ def make_daily_figure(df_obs, x_dates, x_dates_short, y_clim, y_clim_hi, y_clim_
         d1 = pd.Timestamp(window[1]).strftime("%Y-%m-%d")
         layout["xaxis_range"] = [d0, d1]
         layout["xaxis2_range"] = [d0, d1]
-
-        data_lo = min(dates).strftime("%Y-%m-%d")
-        data_hi = max(dates).strftime("%Y-%m-%d")
-
-        # Visible "legend-style" zoom buttons (top row, right side; the
-        # legend is anchored left, so nothing is covered).  Clicks are
-        # wired by the post-script (injected by write_html); each button
-        # keeps the CENTER of the current view and widens around it, so
-        # repeated presses step outward instead of drifting to later years.
-        layout["annotations"] = [
-            dict(text=lab, xref="paper", yref="paper",
-                 x=0.975 - 0.045 * i, y=0.99,
-                 showarrow=False, align="center",
-                 bordercolor="#94a3b8", borderwidth=1, borderpad=3,
-                 bgcolor="white",
-                 font=dict(size=13, color="#1f2937",
-                           family="Segoe UI, Arial, sans-serif"),
-                 opacity=1)
-            for i, lab in enumerate(["1y", "3y", "All"])
-        ]
     fig.update_layout(**layout)
     return fig
-
-
-def write_daily_html(fig, path, data_lo=None, data_hi=None):
-    """Write the figure HTML, then inject the zoom-button click behaviour.
-
-    The plotly Figure object rejects non-standard attributes (e.g.
-    ``post_script``), so the small click handler is appended to the saved
-    HTML file directly — which is fully under our control.
-    """
-    import re
-
-    fig.write_html(path)
-    with open(path, "r", encoding="utf-8") as f:
-        html = f.read()
-
-    if data_lo is None or data_hi is None:
-        return
-
-    script = (
-        "<script>(function(){"
-        "function getGd(){"
-        "if(window.Plotly&&Plotly.figs){var k=Object.keys(Plotly.figs);if(k.length)return Plotly.figs[k[0]];} "
-        "var d=document.querySelectorAll('div');"
-        "for(var i=0;i<d.length;i++){if(d[i]._fullLayout)return d[i];}"
-        "return null;"
-        "}"
-        "var div=getGd();"
-        "if(!div)return;"
-        "var full=['" + data_lo + "','" + data_hi + "'];"
-        "var DAY=86400000;"
-        "function iso(ms){return new Date(ms).toISOString().slice(0,10);} "
-        "function setRange(a,b){Plotly.relayout(div,{'xaxis.range':[a,b],'xaxis2.range':[a,b]});} "
-        "function centerZoom(months){"
-        "var r=(div.layout&&div.layout.xaxis2&&div.layout.xaxis2.range)||"
-        "(div.layout&&div.layout.xaxis.range);"
-        "if(!r)return;"
-        "var a=Date.parse(r[0]),b=Date.parse(r[1]);"
-        "if(isNaN(a)||isNaN(b))return;"
-        "var span=Math.max(b-a,months*30*DAY);"
-        "var mid=a+(b-a)/2;"
-        "setRange(iso(mid-span/2),iso(mid+span/2));"
-        "}"
-        "div.addEventListener('click',function(e){"
-        "var el=e.target;"
-        "var g=el&&el.closest?el.closest('g'):null;"
-        "var txt=((g&&g.textContent)||(el&&el.textContent)||'').trim();"
-        "if(txt==='1y')centerZoom(12);"
-        "else if(txt==='3y')centerZoom(36);"
-        "else if(txt==='All')setRange(full[0],full[1]);"
-        "});"
-        "})();</script>"
-    )
-    html = html.replace("</body>", script + "\n</body>", 1)
-    with open(path, "w", encoding="utf-8") as f:
-        f.write(html)

--- a/noaaplotter/noaaplotter.py
+++ b/noaaplotter/noaaplotter.py
@@ -218,11 +218,11 @@ class NOAAPlotter(object):
             raise Warning("No snow information available")
 
         # ----- plotly engine: interactive figure -----
-        # The interactive figure carries the ENTIRE observed record so users
-        # can browse past the selected period (zoom buttons: 1y / 3y / All);
-        # the initial visible window is set from the requested start/end.
+        # The interactive figure carries the ENTIRE observed record;
+        # the initial visible window is set from the requested start/end
+        # (users can zoom out manually to browse the full record).
         if engine == "plotly":
-            from noaaplotter.figures import make_daily_figure, write_daily_html
+            from noaaplotter.figures import make_daily_figure
 
             # Full-window observed series (all dates actually available)
             df_all = self.dataset.data.sort_values("DATE")
@@ -282,14 +282,9 @@ class NOAAPlotter(object):
                 window=(pd.Timestamp(start_date), pd.Timestamp(end_date)),
             )
             if save_path:
-                out_path = (save_path if str(save_path).endswith(".html")
-                            else str(save_path) + ".html")
-                # write_daily_html() injects the zoom-button click handlers
-                # (the Figure object does not accept a post-script attribute)
-                write_daily_html(
-                    fig_pl, out_path,
-                    data_lo=pd.Timestamp(df_all["DATE"].min()).strftime("%Y-%m-%d"),
-                    data_hi=pd.Timestamp(df_all["DATE"].max()).strftime("%Y-%m-%d"),
+                fig_pl.write_html(
+                    save_path if str(save_path).endswith(".html")
+                    else str(save_path) + ".html"
                 )
             return fig_pl
 

--- a/noaaplotter/noaaplotter.py
+++ b/noaaplotter/noaaplotter.py
@@ -97,11 +97,16 @@ class NOAAPlotter(object):
         title=None,
         return_plot=False,
         engine="matplotlib",
+        full_series=False,
     ):
         """
         Plotting Function to show observed vs climate temperatures and snowfall
         :param engine: "matplotlib" (static, default) or "plotly" (interactive, returned as a plotly Figure)
         :type engine: str
+        :param full_series: plotly only — carry the ENTIRE observed record in the figure
+            and only limit the initial view to the requested window (default: plot only
+            the requested window, lightweight)
+        :type full_series: bool
         :param dpi:
         :param legend_fontsize:
         :param figsize:
@@ -202,6 +207,7 @@ class NOAAPlotter(object):
         ).min(axis=0)
 
         # Calculate the date of last snowfall and cumulative sum of snowfall
+        snow_requested = show_snow_accumulation
         if not show_snow_accumulation:
             None
         elif (show_snow_accumulation) and ("SNOW" in df_obs.columns):
@@ -218,69 +224,127 @@ class NOAAPlotter(object):
             raise Warning("No snow information available")
 
         # ----- plotly engine: interactive figure -----
-        # The interactive figure carries the ENTIRE observed record;
-        # the initial visible window is set from the requested start/end
-        # (users can zoom out manually to browse the full record).
+        # Default: plot ONLY the requested window (lightweight). With
+        # full_series=True the figure carries the ENTIRE observed record and
+        # only the initial view is limited to the requested period.
         if engine == "plotly":
             from noaaplotter.figures import make_daily_figure
 
-            # Full-window observed series (all dates actually available)
-            df_all = self.dataset.data.sort_values("DATE")
-            x_all = pd.DataFrame({
-                "DATE": df_all["DATE"].values,
-                "DATE_MD": df_all["DATE"].dt.strftime("%m-%d").values,
-            }, index=df_all.index)
+            if not full_series:
+                # Lightweight: plot ONLY the requested window. All series are
+                # aligned to the dates that actually exist in the window.
+                src_df = df_obs
+                src_x = x_dates_short
 
-            # Climatology over the full observed window
-            clim_df_all = self.df_clim_.data.loc[x_all["DATE_MD"]].copy()
-            clim_df_all["DATE"] = x_all["DATE"].values
-            clim_df_all = clim_df_all.set_index("DATE", drop=False)
-            y_clim_all = clim_df_all["tmean_doy_mean"]
-            y_clim_std_hi_all = clim_df_all[["tmean_doy_mean", "tmean_doy_std"]].sum(axis=1)
-            y_clim_std_lo_all = clim_df_all["tmean_doy_mean"] - clim_df_all["tmean_doy_std"]
+                # Climatology aligned to the windowed dates
+                y_clim_w = y_clim.reindex(df_obs["DATE"])
+                y_clim_hi_w = y_clim_std_hi.reindex(df_obs["DATE"])
+                y_clim_lo_w = y_clim_std_lo.reindex(df_obs["DATE"])
 
-            # Record extremes over the full window (per month-day)
-            ext_hi = ext_lo = None
-            if plot_extrema:
-                tmax = df_all.groupby("DATE_MD").max(numeric_only=numeric_only)["TMEAN"]
-                tmin = df_all.groupby("DATE_MD").min(numeric_only=numeric_only)["TMEAN"]
-                local_obs = df_all[["DATE", "DATE_MD", "TMEAN"]].set_index(
-                    "DATE_MD", drop=False)
-                local_max = tmax.loc[local_obs.index] == local_obs["TMEAN"]
-                local_min = tmin.loc[local_obs.index] == local_obs["TMEAN"]
-                ext_hi = (
-                    local_obs[local_max]["DATE"].values,
-                    local_obs[local_max]["TMEAN"].values,
+                # Record extremes over the window (per month-day), matching
+                # the static render (which groups the requested window)
+                ext_hi = ext_lo = None
+                if plot_extrema:
+                    tmax = src_df.groupby("DATE_MD").max(numeric_only=numeric_only)["TMEAN"]
+                    tmin = src_df.groupby("DATE_MD").min(numeric_only=numeric_only)["TMEAN"]
+                    local_obs = src_df[["DATE", "DATE_MD", "TMEAN"]].set_index(
+                        "DATE_MD", drop=False)
+                    local_max = tmax.loc[local_obs.index] == local_obs["TMEAN"]
+                    local_min = tmin.loc[local_obs.index] == local_obs["TMEAN"]
+                    ext_hi = (
+                        local_obs[local_max]["DATE"].values,
+                        local_obs[local_max]["TMEAN"].values,
+                    )
+                    ext_lo = (
+                        local_obs[local_min]["DATE"].values,
+                        local_obs[local_min]["TMEAN"].values,
+                    )
+
+                # Snow accumulation over the window (only when requested AND
+                # the window contains snowfall)
+                snow_dates = snow_acc_w = snow_tail = None
+                has_snow = bool(snow_requested and "SNOW" in src_df.columns
+                                and (src_df["SNOW"] > 0).any())
+                if has_snow:
+                    snow_acc_w = np.cumsum(src_df["SNOW"].to_numpy(dtype=float))
+                    pos = int((src_df["DATE"] <= src_df.loc[src_df["SNOW"] > 0, "DATE"].iloc[-1]).sum())
+                    snow_dates = src_df.iloc[:pos]["DATE"].values
+                    snow_tail = (src_df.iloc[pos:]["DATE"].values,
+                                 (snow_acc_w[pos:] / 10))
+
+                fig_pl = make_daily_figure(
+                    src_df, src_x, None,
+                    y_clim_w, y_clim_hi_w, y_clim_lo_w,
+                    ext_hi=ext_hi, ext_lo=ext_lo,
+                    snow_dates=snow_dates,
+                    snow_acc=snow_acc_w,
+                    snow_tail=snow_tail,
+                    show_snow_accumulation=has_snow,
+                    plot_pmax=plot_pmax if isinstance(plot_pmax, (int, float)) else None,
+                    plot_snowmax=plot_snowmax if isinstance(plot_snowmax, (int, float)) else None,
+                    title=title,
+                    figsize=(int(figsize[0] * 100), int(figsize[1] * 100)),
+                    window=None,
                 )
-                ext_lo = (
-                    local_obs[local_min]["DATE"].values,
-                    local_obs[local_min]["TMEAN"].values,
+            else:
+                # Full-window observed series (all dates actually available)
+                src_df = self.dataset.data.sort_values("DATE")
+                src_x = pd.DataFrame({
+                    "DATE": src_df["DATE"].values,
+                    "DATE_MD": src_df["DATE"].dt.strftime("%m-%d").values,
+                }, index=src_df.index)
+
+                # Climatology over the full observed window
+                clim_df_all = self.df_clim_.data.loc[src_x["DATE_MD"]].copy()
+                clim_df_all["DATE"] = src_x["DATE"].values
+                clim_df_all = clim_df_all.set_index("DATE", drop=False)
+                y_clim_w = clim_df_all["tmean_doy_mean"]
+                y_clim_hi_w = clim_df_all[["tmean_doy_mean", "tmean_doy_std"]].sum(axis=1)
+                y_clim_lo_w = clim_df_all["tmean_doy_mean"] - clim_df_all["tmean_doy_std"]
+
+                # Record extremes over the full window (per month-day)
+                ext_hi = ext_lo = None
+                if plot_extrema:
+                    tmax = src_df.groupby("DATE_MD").max(numeric_only=numeric_only)["TMEAN"]
+                    tmin = src_df.groupby("DATE_MD").min(numeric_only=numeric_only)["TMEAN"]
+                    local_obs = src_df[["DATE", "DATE_MD", "TMEAN"]].set_index(
+                        "DATE_MD", drop=False)
+                    local_max = tmax.loc[local_obs.index] == local_obs["TMEAN"]
+                    local_min = tmin.loc[local_obs.index] == local_obs["TMEAN"]
+                    ext_hi = (
+                        local_obs[local_max]["DATE"].values,
+                        local_obs[local_max]["TMEAN"].values,
+                    )
+                    ext_lo = (
+                        local_obs[local_min]["DATE"].values,
+                        local_obs[local_min]["TMEAN"].values,
+                    )
+
+                # Snow accumulation over the full window
+                snow_dates = snow_acc_w = snow_tail = None
+                has_snow = bool(snow_requested and "SNOW" in src_df.columns
+                                and (src_df["SNOW"] > 0).any())
+                if has_snow:
+                    snow_acc_w = np.cumsum(src_df["SNOW"].to_numpy(dtype=float))
+                    pos = int((src_df["DATE"] <= src_df.loc[src_df["SNOW"] > 0, "DATE"].iloc[-1]).sum())
+                    snow_dates = src_df.iloc[:pos]["DATE"].values
+                    snow_tail = (src_df.iloc[pos:]["DATE"].values,
+                                 (snow_acc_w[pos:] / 10))
+
+                fig_pl = make_daily_figure(
+                    src_df, src_x, None,
+                    y_clim_w, y_clim_hi_w, y_clim_lo_w,
+                    ext_hi=ext_hi, ext_lo=ext_lo,
+                    snow_dates=snow_dates,
+                    snow_acc=snow_acc_w,
+                    snow_tail=snow_tail,
+                    show_snow_accumulation=has_snow,
+                    plot_pmax=plot_pmax if isinstance(plot_pmax, (int, float)) else None,
+                    plot_snowmax=plot_snowmax if isinstance(plot_snowmax, (int, float)) else None,
+                    title=title,
+                    figsize=(int(figsize[0] * 100), int(figsize[1] * 100)),
+                    window=(pd.Timestamp(start_date), pd.Timestamp(end_date)),
                 )
-
-            # Snow accumulation over the full window
-            has_snow = show_snow_accumulation and "SNOW" in df_all.columns and bool(
-                (df_all["SNOW"] > 0).any())
-            snow_dates_all = snow_acc_all = snow_tail_all = None
-            if has_snow:
-                snow_acc_all = np.cumsum(df_all["SNOW"].to_numpy(dtype=float))
-                pos = int((df_all["DATE"] <= df_all.loc[df_all["SNOW"] > 0, "DATE"].iloc[-1]).sum())
-                snow_dates_all = df_all.iloc[:pos]["DATE"].values
-                snow_tail_all = (df_all.iloc[pos:]["DATE"].values, (snow_acc_all[pos:] / 10))
-
-            fig_pl = make_daily_figure(
-                df_all, x_all, None,
-                y_clim_all, y_clim_std_hi_all, y_clim_std_lo_all,
-                ext_hi=ext_hi, ext_lo=ext_lo,
-                snow_dates=snow_dates_all,
-                snow_acc=snow_acc_all,
-                snow_tail=snow_tail_all,
-                show_snow_accumulation=has_snow,
-                plot_pmax=plot_pmax if isinstance(plot_pmax, (int, float)) else None,
-                plot_snowmax=plot_snowmax if isinstance(plot_snowmax, (int, float)) else None,
-                title=title,
-                figsize=(int(figsize[0] * 100), int(figsize[1] * 100)),
-                window=(pd.Timestamp(start_date), pd.Timestamp(end_date)),
-            )
             if save_path:
                 fig_pl.write_html(
                     save_path if str(save_path).endswith(".html")

--- a/noaaplotter/noaaplotter.py
+++ b/noaaplotter/noaaplotter.py
@@ -218,20 +218,34 @@ class NOAAPlotter(object):
             raise Warning("No snow information available")
 
         # ----- plotly engine: interactive figure -----
+        # The interactive figure carries the ENTIRE observed record so users
+        # can browse past the selected period (zoom buttons: 1y / 3y / All);
+        # the initial visible window is set from the requested start/end.
         if engine == "plotly":
             from noaaplotter.figures import make_daily_figure
 
+            # Full-window observed series (all dates actually available)
+            df_all = self.dataset.data.sort_values("DATE")
+            x_all = pd.DataFrame({
+                "DATE": df_all["DATE"].values,
+                "DATE_MD": df_all["DATE"].dt.strftime("%m-%d").values,
+            }, index=df_all.index)
+
+            # Climatology over the full observed window
+            clim_df_all = self.df_clim_.data.loc[x_all["DATE_MD"]].copy()
+            clim_df_all["DATE"] = x_all["DATE"].values
+            clim_df_all = clim_df_all.set_index("DATE", drop=False)
+            y_clim_all = clim_df_all["tmean_doy_mean"]
+            y_clim_std_hi_all = clim_df_all[["tmean_doy_mean", "tmean_doy_std"]].sum(axis=1)
+            y_clim_std_lo_all = clim_df_all["tmean_doy_mean"] - clim_df_all["tmean_doy_std"]
+
+            # Record extremes over the full window (per month-day)
             ext_hi = ext_lo = None
             if plot_extrema:
-                tmax = self.dataset.data.groupby("DATE_MD").max(
-                    numeric_only=numeric_only
-                )["TMEAN"]
-                tmin = self.dataset.data.groupby("DATE_MD").min(
-                    numeric_only=numeric_only
-                )["TMEAN"]
-                local_obs = df_obs[["DATE", "DATE_MD", "TMEAN"]].set_index(
-                    "DATE_MD", drop=False
-                )
+                tmax = df_all.groupby("DATE_MD").max(numeric_only=numeric_only)["TMEAN"]
+                tmin = df_all.groupby("DATE_MD").min(numeric_only=numeric_only)["TMEAN"]
+                local_obs = df_all[["DATE", "DATE_MD", "TMEAN"]].set_index(
+                    "DATE_MD", drop=False)
                 local_max = tmax.loc[local_obs.index] == local_obs["TMEAN"]
                 local_min = tmin.loc[local_obs.index] == local_obs["TMEAN"]
                 ext_hi = (
@@ -243,25 +257,29 @@ class NOAAPlotter(object):
                     local_obs[local_min]["TMEAN"].values,
                 )
 
-            has_snow = show_snow_accumulation and "SNOW" in df_obs.columns
+            # Snow accumulation over the full window
+            has_snow = show_snow_accumulation and "SNOW" in df_all.columns and bool(
+                (df_all["SNOW"] > 0).any())
+            snow_dates_all = snow_acc_all = snow_tail_all = None
+            if has_snow:
+                snow_acc_all = np.cumsum(df_all["SNOW"].to_numpy(dtype=float))
+                pos = int((df_all["DATE"] <= df_all.loc[df_all["SNOW"] > 0, "DATE"].iloc[-1]).sum())
+                snow_dates_all = df_all.iloc[:pos]["DATE"].values
+                snow_tail_all = (df_all.iloc[pos:]["DATE"].values, (snow_acc_all[pos:] / 10))
+
             fig_pl = make_daily_figure(
-                df_obs, x_dates, x_dates_short,
-                y_clim, y_clim_std_hi, y_clim_std_lo,
+                df_all, x_all, None,
+                y_clim_all, y_clim_std_hi_all, y_clim_std_lo_all,
                 ext_hi=ext_hi, ext_lo=ext_lo,
-                snow_dates=(
-                    x_dates_short.loc[:last_snow_date, "DATE"].values
-                    if has_snow else None
-                ),
-                snow_acc=snow_acc if has_snow else None,
-                snow_tail=(
-                    x_dates_short.loc[last_snow_date:, "DATE"].values,
-                    (snow_acc / 10)[x_dates_short.index.get_loc(last_snow_date):],
-                ) if has_snow else None,
+                snow_dates=snow_dates_all,
+                snow_acc=snow_acc_all,
+                snow_tail=snow_tail_all,
                 show_snow_accumulation=has_snow,
                 plot_pmax=plot_pmax if isinstance(plot_pmax, (int, float)) else None,
                 plot_snowmax=plot_snowmax if isinstance(plot_snowmax, (int, float)) else None,
                 title=title,
                 figsize=(int(figsize[0] * 100), int(figsize[1] * 100)),
+                window=(pd.Timestamp(start_date), pd.Timestamp(end_date)),
             )
             if save_path:
                 fig_pl.write_html(

--- a/noaaplotter/noaaplotter.py
+++ b/noaaplotter/noaaplotter.py
@@ -241,12 +241,13 @@ class NOAAPlotter(object):
                 y_clim_hi_w = y_clim_std_hi.reindex(df_obs["DATE"])
                 y_clim_lo_w = y_clim_std_lo.reindex(df_obs["DATE"])
 
-                # Record extremes over the window (per month-day), matching
-                # the static render (which groups the requested window)
+                # Record extremes: analysis over the ENTIRE record (per
+                # month-day), then cropped to the plotted window — exactly
+                # like the static render (groupby on the full dataset).
                 ext_hi = ext_lo = None
                 if plot_extrema:
-                    tmax = src_df.groupby("DATE_MD").max(numeric_only=numeric_only)["TMEAN"]
-                    tmin = src_df.groupby("DATE_MD").min(numeric_only=numeric_only)["TMEAN"]
+                    tmax = self.dataset.data.groupby("DATE_MD").max(numeric_only=numeric_only)["TMEAN"]
+                    tmin = self.dataset.data.groupby("DATE_MD").min(numeric_only=numeric_only)["TMEAN"]
                     local_obs = src_df[["DATE", "DATE_MD", "TMEAN"]].set_index(
                         "DATE_MD", drop=False)
                     local_max = tmax.loc[local_obs.index] == local_obs["TMEAN"]

--- a/noaaplotter/noaaplotter.py
+++ b/noaaplotter/noaaplotter.py
@@ -222,7 +222,7 @@ class NOAAPlotter(object):
         # can browse past the selected period (zoom buttons: 1y / 3y / All);
         # the initial visible window is set from the requested start/end.
         if engine == "plotly":
-            from noaaplotter.figures import make_daily_figure
+            from noaaplotter.figures import make_daily_figure, write_daily_html
 
             # Full-window observed series (all dates actually available)
             df_all = self.dataset.data.sort_values("DATE")
@@ -282,9 +282,14 @@ class NOAAPlotter(object):
                 window=(pd.Timestamp(start_date), pd.Timestamp(end_date)),
             )
             if save_path:
-                fig_pl.write_html(
-                    save_path if str(save_path).endswith(".html")
-                    else str(save_path) + ".html"
+                out_path = (save_path if str(save_path).endswith(".html")
+                            else str(save_path) + ".html")
+                # write_daily_html() injects the zoom-button click handlers
+                # (the Figure object does not accept a post-script attribute)
+                write_daily_html(
+                    fig_pl, out_path,
+                    data_lo=pd.Timestamp(df_all["DATE"].min()).strftime("%Y-%m-%d"),
+                    data_hi=pd.Timestamp(df_all["DATE"].max()).strftime("%Y-%m-%d"),
                 )
             return fig_pl
 


### PR DESCRIPTION
Short review of the changes to the **interactive** daily plot (static matplotlib engine untouched):

## 1. Full time series + browsable selected window
`make_daily_figure` gets the complete observed record when `engine="plotly"`; the selected start/end now only sets the **initial x-range**. A rangeselector row (`1y` / `3y` / `All`) lets users zoom out step by step to browse past the selected period. Climatology, record-extrema and snow accumulation are all computed over the full series as well.

## 2. Y-limits include all visible values
The precipitation axis top now also accounts for the **7-day rolling sum** (which regularly exceeds the max daily bar — the reported clipping). The temperature axis range is derived from observed + climatology over the full series. User-supplied `-p_range` / `-s_range` still cap the respective axes.

## 3. Calendar-year background
Alternating light-grey and white full-height bands per calendar year on both panels (grey = odd years — same convention as the monthly plots), drawn below all other traces.

## Changes
- `noaaplotter/figures/plotly_daily.py` — year-band helper, rolling-sum-aware precip y-range, `window=` param, `rangeselector` initial view
- `noaaplotter/noaaplotter.py` — plotly branch now assembles full-window observed series, climatology, extremes, and snow instead of the selected-window slice

## Verification (executed, Kotzebue 1970-01-01 → 2026-09-05, 20,697 rows)

| check | result |
|---|---|
| selection 1992 → initial x-range | `['1992-01-01','1992-12-31']` ✓ |
| full series present | 20,697 obs points, first 1970-01-01, last 2026-09-05 ✓ |
| zoom buttons | `1y` / `3y` / `All` on xaxis ✓ |
| precip y-range | `[0, 84.2]` ≥ rolling max `73.2` ✓ |
| temperature y-range | `[-43.05, 23.35]` ⊇ observed `[-43.0, 23.4]` ✓ |
| year bands | 28 per panel (odd years grey, even white) ✓ |
| snow axis / cumulative snowfall | renders over full series, last SNOW>0 = 2019-10-30 (matches data) ✓ |
| regression: static `plot-daily` (1992, `t_range`) | exit 0, PNG ✓ |
| regression: `plot-monthly` (1980–2021) | exit 0, PNG ✓ |

**Notes**
- Plotly 7 note: `add_vrect` silently no-ops in this version, so the bands use `add_shape` with `yref="<axis> domain"` — equivalent, and verified to render.
- The `yaxis.rangeselector` (vs. layout-level `xaxis_rangeselector`) placement is intentional: it's the standard for plotly subplot figures.
